### PR TITLE
fix: Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,17 @@ FROM php:8.4-cli
 # 1) Zainstaluj biblioteki deweloperskie i narzędzia
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    libxml2-dev \          
-    libcurl4-openssl-dev \ 
-    libonig-dev \          
-    pkg-config \           
-    libsqlite3-dev \       
+    libonig-dev \
+    libsqlite3-dev \
     unzip \
     git \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # 2) Skonfiguruj i zainstaluj rozszerzenia PHP
 RUN docker-php-ext-install \
-    mbstring \            
-    dom \                 
-    pdo_sqlite \          
-    curl                  
+    mbstring \
+    pdo_sqlite               
 
 # 3) Composer i Symfony CLI
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
## Why

As described in #14, docker was not builiding correctly

## Changes

Removed unnecessary build libraries and php extensions, as well as improving installation commands

## Testing

In order to test this changes make sure that:
- you have docker running
- you are on this branch locally and have up-to-date changes
- have your own `.env` file

Steps:
1. Open up a terminal (or cmd) and run this command in project root:
```
docker-compose up --build -d
```
2. Check if containers build without any error. You should see something simmilar to screen below:

<img width="677" height="180" alt="image" src="https://github.com/user-attachments/assets/92357ddf-2218-419a-a87d-58fb496af284" />
